### PR TITLE
added process properties to logfileinfo

### DIFF
--- a/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/LogFileInfo.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/LogFileInfo.cs
@@ -1,6 +1,7 @@
 ﻿namespace Serilog.Sinks.RollingFileAlternate.Sinks.SizeRollingFileSink
 {
     using System;
+    using System.Diagnostics;
     using System.IO;
     using System.Text.RegularExpressions;
 
@@ -12,12 +13,14 @@
         internal uint Sequence { get; private set; }
         internal string FileName { get; private set; }
         internal DateTime Date { get; private set; }
+        internal int ProcessId { get; private set; }
 
         public LogFileInfo(DateTime date, uint sequence)
         {
             this.Date = date;
             this.Sequence = sequence;
-            this.FileName = String.Format("{0}-{1}.log", date.ToString(DateFormat), sequence.ToString(NumberFormat));
+            this.ProcessId = GetProcessId();
+            this.FileName = String.Format("{0}-{1}-{2}.log", date.ToString(DateFormat), sequence.ToString(NumberFormat), this.ProcessId);
         }
 
         public LogFileInfo Next()
@@ -31,11 +34,33 @@
             return new LogFileInfo(now, this.Sequence + 1);
         }
 
+        private int GetProcessId()
+        {
+            var process = Process.GetCurrentProcess();
+            if (process != null)
+            {
+                return process.Id;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
         internal static LogFileInfo GetLatestOrNew(DateTime date, string logDirectory)
         {
-            string pattern = date.ToString(DateFormat) + @"-(\d{5}).log";
-
+            string pattern;
             var logFileInfo = new LogFileInfo(date, 1);
+
+            if (logFileInfo.ProcessId == 0)
+            {
+                pattern = date.ToString(DateFormat) + @"-(\d{5}).log";
+            }
+            else
+            {
+                pattern = string.Format("{0}-{1}-{2}.log", date.ToString(DateFormat), @"(\d{5})", logFileInfo.ProcessId);
+            }
+
 
             foreach (var filePath in Directory.GetFiles(logDirectory))
             {

--- a/test/Serilog.Sinks.RollingFileAlternate.Tests/LogFileInfoTests.cs
+++ b/test/Serilog.Sinks.RollingFileAlternate.Tests/LogFileInfoTests.cs
@@ -12,7 +12,14 @@ namespace Serilog.Sinks.RollingFileAlternate.Tests
         public void RendersCorrectlyWithDateAndSequenceNumber()
         {
             var sut = new LogFileInfo(new DateTime(2015, 01, 15), 77);
-            Assert.That(sut.FileName, Is.EqualTo("20150115-00077.log"));
+            Assert.That(sut.FileName, Is.EqualTo(string.Format("{0}-{1}.{2}", "20150115-00077", sut.ProcessId, "log")));
+        }
+
+        [Test]
+        public void FileContainsProcessId()
+        {       
+            var logInfo = new LogFileInfo(new DateTime(2016, 01, 05), 1);
+            Assert.That(logInfo.FileName.Contains(logInfo.ProcessId.ToString()));
         }
     }
 }

--- a/test/Serilog.Sinks.RollingFileAlternate.Tests/LogFileInfoTests.cs
+++ b/test/Serilog.Sinks.RollingFileAlternate.Tests/LogFileInfoTests.cs
@@ -12,7 +12,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Tests
         public void RendersCorrectlyWithDateAndSequenceNumber()
         {
             var sut = new LogFileInfo(new DateTime(2015, 01, 15), 77);
-            Assert.That(sut.FileName, Is.EqualTo(string.Format("{0}-{1}.{2}", "20150115-00077", sut.ProcessId, "log")));
+            Assert.That(sut.FileName, Is.EqualTo(string.Format("{0}-{1}-{2}-{3}", "20150115", sut.ProcessId, sut.ProcessName, "00077.log")));
         }
 
         [Test]
@@ -20,6 +20,12 @@ namespace Serilog.Sinks.RollingFileAlternate.Tests
         {       
             var logInfo = new LogFileInfo(new DateTime(2016, 01, 05), 1);
             Assert.That(logInfo.FileName.Contains(logInfo.ProcessId.ToString()));
+        }
+
+        public void FileContainsProcessNamePossiblyTruncated()
+        {
+            var logInfo = new LogFileInfo(new DateTime(2016, 01, 05), 1);
+            Assert.That(logInfo.FileName.Contains(logInfo.ProcessName.ToString()));
         }
     }
 }

--- a/test/Serilog.Sinks.RollingFileAlternate.Tests/Serilog.Sinks.RollingFileAlternate.Tests.csproj
+++ b/test/Serilog.Sinks.RollingFileAlternate.Tests/Serilog.Sinks.RollingFileAlternate.Tests.csproj
@@ -70,6 +70,9 @@
       <Name>Serilog.Sinks.RollingFileAlternate</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Hi Joseph,
Really nice work on an alternate to Serilog's built-in rolling file logger. I've added a bit more to the log file name to make it easier to identify the source by process id and a potentially truncated process name. 
