### PR TITLE
Make NETStandard.Library 1.6 as the dependency for netstandard1.6 only

### DIFF
--- a/src/Serilog.Sinks.RollingFileAlternate/packages.config
+++ b/src/Serilog.Sinks.RollingFileAlternate/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Serilog" version="1.5.7" targetFramework="net45" />
-</packages>

--- a/src/Serilog.Sinks.RollingFileAlternate/project.json
+++ b/src/Serilog.Sinks.RollingFileAlternate/project.json
@@ -10,12 +10,11 @@
       "url": "https://github.com/bedegaming/sinks-rollingfile"
     }
   },
-  "version": "2.0.3",
+  "version": "2.0.4",
   "authors": [ "martin.shinz", "joseph.jeganathan" ],
   "description": "A serilog sink for rolling files based on size and time",
   "title": "Serilog Rolling File Alternative",
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
     "Serilog": "2.0.0"
   },
 
@@ -30,6 +29,7 @@
     },
     "netstandard1.6": {
       "dependencies": {
+        "NETStandard.Library": "1.6.0",
         "System.IO": "4.1.0",
         "System.Text.RegularExpressions": "4.1.0"
       }

--- a/test/Serilog.Sinks.RollingFileAlternate.Tests/packages.config
+++ b/test/Serilog.Sinks.RollingFileAlternate.Tests/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Serilog" version="1.5.7" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
Also get rid of packages.config files as they are not used.