### PR TITLE
Adding RetainedFileCountLimit

### DIFF
--- a/src/Serilog.Sinks.RollingFileAlternate/LoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/LoggerConfigurationExtensions.cs
@@ -29,6 +29,8 @@ namespace Serilog.Sinks.RollingFileAlternate
         /// <param name="outputTemplate">The template for substituting logged parameters</param>
         /// <param name="formatProvider">A culture specific format provider</param>
         /// <param name="fileSizeLimitBytes">The size files should grow up to (default 2MB)</param>
+        /// <param name="retainedFileCountLimit">The maximum number of log files that will be retained,
+        /// including the current log file. The default is null which is unlimited.</param>
         /// <returns></returns>
         public static LoggerConfiguration RollingFileAlternate(
             this LoggerSinkConfiguration configuration,
@@ -36,7 +38,8 @@ namespace Serilog.Sinks.RollingFileAlternate
             LogEventLevel minimumLevel = LevelAlias.Minimum,
             string outputTemplate = DefaultOutputTemplate,
             IFormatProvider formatProvider = null,
-            long? fileSizeLimitBytes = null)
+            long? fileSizeLimitBytes = null,
+            int? retainedFileCountLimit = null)
         {
             if (configuration == null)
             {
@@ -44,7 +47,7 @@ namespace Serilog.Sinks.RollingFileAlternate
             }
 
             var templateFormatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
-            var sink = new AlternateRollingFileSink(logDirectory, templateFormatter, fileSizeLimitBytes ?? TwoMegabytes);
+            var sink = new AlternateRollingFileSink(logDirectory, templateFormatter, fileSizeLimitBytes ?? TwoMegabytes, retainedFileCountLimit);
             return configuration.Sink(sink, minimumLevel);
         }
 
@@ -56,13 +59,16 @@ namespace Serilog.Sinks.RollingFileAlternate
         /// <param name="minimumLevel">Minimum <see cref="LogLevel"/></param>
         /// <param name="outputTemplate">The template for substituting logged parameters</param>
         /// <param name="formatProvider">A culture specific format provider</param>
+        /// <param name="retainedFileCountLimit">The maximum number of log files that will be retained,
+        /// including the current log file. The default is null which is unlimited.</param>
         /// <returns></returns>
         public static LoggerConfiguration HourlyRollingFileAlternate(
             this LoggerSinkConfiguration configuration,
             string logDirectory,
             LogEventLevel minimumLevel = LevelAlias.Minimum,
             string outputTemplate = DefaultOutputTemplate,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            int? retainedFileCountLimit = null)
         {
             if (configuration == null)
             {
@@ -70,7 +76,7 @@ namespace Serilog.Sinks.RollingFileAlternate
             }
 
             var templateFormatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
-            var sink = new HourlyRollingFileSink(logDirectory, templateFormatter);
+            var sink = new HourlyRollingFileSink(logDirectory, templateFormatter, retainedFileCountLimit);
             return configuration.Sink(sink, minimumLevel);
         }
     }

--- a/src/Serilog.Sinks.RollingFileAlternate/project.json
+++ b/src/Serilog.Sinks.RollingFileAlternate/project.json
@@ -10,7 +10,7 @@
       "url": "https://github.com/bedegaming/sinks-rollingfile"
     }
   },
-  "version": "2.0.5",
+  "version": "2.0.6",
   "authors": [ "martin.shinz", "joseph.jeganathan" ],
   "description": "A serilog sink for rolling files based on size and time",
   "title": "Serilog Rolling File Alternative",

--- a/test/Serilog.Sinks.RollingFileAlternate.Tests/MultipleSinksTests.cs
+++ b/test/Serilog.Sinks.RollingFileAlternate.Tests/MultipleSinksTests.cs
@@ -24,7 +24,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Tests
         {
             var formatter = new RawFormatter();
 
-            return new AlternateRollingFileSink(@"c:\temp", formatter, 100000, Encoding.UTF8);
+            return new AlternateRollingFileSink(@"c:\temp", formatter, 100000, null, Encoding.UTF8);
         }
     }
 }


### PR DESCRIPTION
The default Serilog RollingFile implementation has the ability to set the RetainedFileCountLimit. This deletes any files over the set limit when the log file rolls over. 

The default implementation has a default of 31 days (as it only rolls over on a day basis, this implementation keeps the existing behaviour of unlimited log files by keeping the default set as null.