### PR TITLE
ITextFormatter support for both sinks

### DIFF
--- a/src/Serilog.Sinks.RollingFileAlternate/LoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/LoggerConfigurationExtensions.cs
@@ -50,6 +50,37 @@ namespace Serilog.Sinks.RollingFileAlternate
             var sink = new AlternateRollingFileSink(logDirectory, templateFormatter, fileSizeLimitBytes ?? TwoMegabytes, retainedFileCountLimit);
             return configuration.Sink(sink, minimumLevel);
         }
+        
+        /// <summary>
+        /// Creates an alternative implementation of the rolling file sink with
+        /// an overload to pass an ITextFormatter.
+        /// </summary>
+        /// <param name="configuration"><see cref="LoggerSinkConfiguration"/></param>
+        /// <param name="formatter">Formatter to control how events are rendered into the file. To control
+        /// plain text formatting, use the overload that accepts an output template instead.</param>
+        /// <param name="logDirectory">The names of the directory to be logged</param>
+        /// <param name="minimumLevel">Minimum <see cref="LogLevel"/></param>
+        /// <param name="fileSizeLimitBytes">The size files should grow up to (default 2MB)</param>
+        /// <param name="retainedFileCountLimit">The maximum number of log files that will be retained,
+        /// including the current log file. The default is null which is unlimited.</param>
+        /// <returns></returns>
+        public static LoggerConfiguration RollingFileAlternate(
+            this LoggerSinkConfiguration configuration,
+            ITextFormatter formatter,
+            string logDirectory,
+            LogEventLevel minimumLevel = LevelAlias.Minimum,
+            long? fileSizeLimitBytes = null,
+            int? retainedFileCountLimit = null)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException("configuration");
+            }
+            
+            var sink = new AlternateRollingFileSink(logDirectory, formatter, fileSizeLimitBytes ?? TwoMegabytes,
+                retainedFileCountLimit);
+            return configuration.Sink(sink, minimumLevel);
+        }
 
         /// <summary>
         /// Creates an hourly rolling file sink that rolls files every hour.
@@ -77,6 +108,34 @@ namespace Serilog.Sinks.RollingFileAlternate
 
             var templateFormatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
             var sink = new HourlyRollingFileSink(logDirectory, templateFormatter, retainedFileCountLimit);
+            return configuration.Sink(sink, minimumLevel);
+        }
+        
+        /// <summary>
+        /// Creates an hourly rolling file sink that rolls files every hour with an
+        /// overload to pass ITextFormatter.
+        /// </summary>
+        /// <param name="configuration"><see cref="LoggerSinkConfiguration"/></param>
+        /// <param name="formatter">Formatter to control how events are rendered into the file. To control
+        /// plain text formatting, use the overload that accepts an output template instead.</param>
+        /// <param name="logDirectory">The names of the directory to be logged</param>
+        /// <param name="minimumLevel">Minimum <see cref="LogLevel"/></param>
+        /// <param name="retainedFileCountLimit">The maximum number of log files that will be retained,
+        /// including the current log file. The default is null which is unlimited.</param>
+        /// <returns></returns>
+        public static LoggerConfiguration HourlyRollingFileAlternate(
+            this LoggerSinkConfiguration configuration,
+            ITextFormatter formatter,
+            string logDirectory,
+            LogEventLevel minimumLevel = LevelAlias.Minimum,
+            int? retainedFileCountLimit = null)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException("configuration");
+            }
+
+            var sink = new HourlyRollingFileSink(logDirectory, formatter, retainedFileCountLimit);
             return configuration.Sink(sink, minimumLevel);
         }
     }


### PR DESCRIPTION
Allows for the overloaded option to pass an ITextFormatter from the Serilog framework. This enhances the options of the Alternative Rolling File Sink as it can now output in JSON, Raw, or Display formats. If there are new formats added to the Serilog framework, they would be supported as well. 

This is functionality that exists in the Serilog Rolling File sink and should be extended to the Alternative Rolling File sink.