### PR TITLE
Roll over when the date changes.

### DIFF
--- a/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/AlternateRollingFileSink.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/AlternateRollingFileSink.cs
@@ -72,8 +72,8 @@ namespace Serilog.Sinks.RollingFileAlternate.Sinks.SizeRollingFileSink
                 {
                     throw new ObjectDisposedException(ThisObjectName, "The rolling file sink has been disposed");
                 }
-
-                if (this.currentSink.SizeLimitReached)
+                bool newDay = this.currentSink.LogFileDescription.LogFileInfo.Date.Date != DateTime.Now.Date
+                if (this.currentSink.SizeLimitReached || newDay)
                 {
                     this.currentSink = NextSizeLimitedFileSink();
                 }

--- a/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/AlternateRollingFileSink.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/AlternateRollingFileSink.cs
@@ -72,7 +72,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Sinks.SizeRollingFileSink
                 {
                     throw new ObjectDisposedException(ThisObjectName, "The rolling file sink has been disposed");
                 }
-                bool newDay = this.currentSink.LogFileDescription.LogFileInfo.Date.Date != DateTime.Now.Date
+                bool newDay = this.currentSink.LogFileDescription.LogFileInfo.Date.Date != DateTime.UtcNow.Date
                 if (this.currentSink.SizeLimitReached || newDay)
                 {
                     this.currentSink = NextSizeLimitedFileSink();


### PR DESCRIPTION
When the new day starts, the log files written still have the previous date string in the file name until a new file is created on that day. This change will make sure that a new log file gets created when the date changes.