### PR TITLE
Task/fix file locking on hourly sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ var log = new LoggerConfiguration()
     .WriteTo.RollingFileAlternate(".\\logs")
     .CreateLogger();
     
-Log.Information("This will be written to the rolling file set");
+log.Information("This will be written to the rolling file set");
 ```
 
 The sink is configured with the path of a folder for the log file set:

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-### 2.0.6 (Released 2017/01/26)
+### 2.0.7 (Released 2017/01/26)
 * Fixed bug where files weren't rolling over at midnight
 * Fixed bug where hourly sink couldn't log if the file was locked
 * ITextFormatter support added for both sinks

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### 2.0.6 (Released 2017/01/26)
+* Fixed bug where files weren't rolling over at midnight
+* Fixed bug where hourly sink couldn't log if the file was locked
+* ITextFormatter support added for both sinks
+
 ### 2.0.5 (Released 2016/11/02)
 * Unsealing HourlyRollingFileSink to allow for extension
 

--- a/src/Serilog.Sinks.RollingFileAlternate/Sinks/HourlyRolling/HourlyLogFileDescription.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/Sinks/HourlyRolling/HourlyLogFileDescription.cs
@@ -4,20 +4,27 @@ namespace Serilog.Sinks.RollingFileAlternate.Sinks.HourlyRolling
 {
     internal class HourlyLogFileDescription
     {
-        private readonly DateTime dateTime;
+        public readonly HourlyLogFileInfo LogFileInfo;
 
-        internal HourlyLogFileDescription(DateTime dateTime)
+        internal HourlyLogFileDescription(HourlyLogFileInfo logFileInfo, DateTime dateTime)
         {
-            this.dateTime = dateTime;
+            this.LogFileInfo = logFileInfo;
+            this.DateTime = dateTime;
         }
 
-        internal string FileName { get { return string.Format("{0}.log", this.dateTime.ToString("HH")); } }
+        // internal string FileName { get { return string.Format("{0}.log", this.dateTime.ToString("HH")); } }
+        public string FileName { get { return LogFileInfo.FileName; } }
 
-        internal DateTime Date { get { return this.dateTime.Date; } }
+        public DateTime DateTime { get; private set; }
 
         internal bool SameHour(DateTime logEventAt)
         {
-            return this.dateTime.Date == logEventAt.Date && this.dateTime.Hour == logEventAt.Hour;
+            return this.DateTime.Date == logEventAt.Date && this.DateTime.Hour == logEventAt.Hour;
+        }
+
+        internal HourlyLogFileDescription Next()
+        {
+            return new HourlyLogFileDescription(this.LogFileInfo.Next(), DateTime.UtcNow);
         }
     }
 }

--- a/src/Serilog.Sinks.RollingFileAlternate/Sinks/HourlyRolling/HourlyLogFileInfo.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/Sinks/HourlyRolling/HourlyLogFileInfo.cs
@@ -2,40 +2,40 @@
 using System.IO;
 using System.Text.RegularExpressions;
 
-namespace Serilog.Sinks.RollingFileAlternate.Sinks.SizeRollingFileSink
+namespace Serilog.Sinks.RollingFileAlternate.Sinks.HourlyRolling
 {
-    internal class LogFileInfo
+    internal class HourlyLogFileInfo
     {
         private const string NumberFormat = "00000";
-        private const string DateFormat = "yyyyMMdd";
+        private const string DateFormat = "HH";
 
         internal uint Sequence { get; private set; }
         internal string FileName { get; private set; }
         internal DateTime Date { get; private set; }
 
-        public LogFileInfo(DateTime date, uint sequence)
+        public HourlyLogFileInfo(DateTime date, uint sequence)
         {
             this.Date = date;
             this.Sequence = sequence;
             this.FileName = String.Format("{0}-{1}.log", date.ToString(DateFormat), sequence.ToString(NumberFormat));
         }
 
-        public LogFileInfo Next()
+        public HourlyLogFileInfo Next()
         {
             DateTime now = DateTime.UtcNow;
-            if (this.Date.Date != now.Date)
+            if (this.Date.Hour != now.Hour)
             {
-                return new LogFileInfo(now, 1);
+                return new HourlyLogFileInfo(now, 1);
             }
 
-            return new LogFileInfo(now, this.Sequence + 1);
+            return new HourlyLogFileInfo(now, this.Sequence + 1);
         }
 
-        internal static LogFileInfo GetLatestOrNew(DateTime date, string logDirectory)
+        internal static HourlyLogFileInfo GetLatestOrNew(DateTime date, string logDirectory)
         {
             string pattern = date.ToString(DateFormat) + @"-(\d{5}).log";
 
-            var logFileInfo = new LogFileInfo(date, 1);
+            var logFileInfo = new HourlyLogFileInfo(date, 1);
 
             foreach (var filePath in Directory.GetFiles(logDirectory))
             {
@@ -46,7 +46,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Sinks.SizeRollingFileSink
 
                     if (sequence > logFileInfo.Sequence)
                     {
-                        logFileInfo = new LogFileInfo(date, sequence);
+                        logFileInfo = new HourlyLogFileInfo(date, sequence);
                     }
                 }
             }

--- a/src/Serilog.Sinks.RollingFileAlternate/Sinks/HourlyRolling/HourlyRollingFileSink.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/Sinks/HourlyRolling/HourlyRollingFileSink.cs
@@ -81,20 +81,33 @@ namespace Serilog.Sinks.RollingFileAlternate.Sinks.HourlyRolling
 
         private HourlyFileSink GetLatestSink()
         {
+            EnsureDirectoryCreated(this.logDirectory);
+
+            HourlyLogFileInfo logFileInfo = HourlyLogFileInfo.GetLatestOrNew(DateTime.UtcNow, this.logDirectory);
+
             return new HourlyFileSink(
                 this.formatter,
                 this.logDirectory,
-                new HourlyLogFileDescription(DateTime.UtcNow),
+                new HourlyLogFileDescription(logFileInfo, DateTime.UtcNow),
                 this.encoding);
         }
 
         private HourlyFileSink NextFileSink(DateTime dateTimeUtc)
         {
-            var next = new HourlyLogFileDescription(dateTimeUtc);
+            HourlyLogFileDescription next = this.currentSink.LogFileDescription.Next();
+
             ApplyRetentionPolicy();
             this.currentSink.Dispose();
 
             return new HourlyFileSink(this.formatter, this.logDirectory, next, this.encoding);
+        }
+
+        private static void EnsureDirectoryCreated(string path)
+        {
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
         }
 
         private void ApplyRetentionPolicy()

--- a/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/AlternateRollingFileSink.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/AlternateRollingFileSink.cs
@@ -89,7 +89,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Sinks.SizeRollingFileSink
         {
             EnsureDirectoryCreated(this.logDirectory);
 
-            LogFileInfo logFileInfo = LogFileInfo.GetLatestOrNew(DateTime.UtcNow, this.logDirectory);
+            SizeLimitedLogFileInfo logFileInfo = SizeLimitedLogFileInfo.GetLatestOrNew(DateTime.UtcNow, this.logDirectory);
 
             return new SizeLimitedFileSink(
                 this.formatter,

--- a/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/SizeLimitedLogFileDescription.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/SizeLimitedLogFileDescription.cs
@@ -3,9 +3,9 @@
     internal class SizeLimitedLogFileDescription
     {
         public readonly long SizeLimitBytes;
-        public readonly LogFileInfo LogFileInfo;
+        public readonly SizeLimitedLogFileInfo LogFileInfo;
 
-        public SizeLimitedLogFileDescription(LogFileInfo logFileInfo, long sizeLimitBytes)
+        public SizeLimitedLogFileDescription(SizeLimitedLogFileInfo logFileInfo, long sizeLimitBytes)
         {
             LogFileInfo = logFileInfo;
             SizeLimitBytes = sizeLimitBytes;

--- a/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/SizeLimitedLogFileInfo.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/SizeLimitedLogFileInfo.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Serilog.Sinks.RollingFileAlternate.Sinks.SizeRollingFileSink
+{
+    internal class SizeLimitedLogFileInfo
+    {
+        private const string NumberFormat = "00000";
+        private const string DateFormat = "yyyyMMdd";
+
+        internal uint Sequence { get; private set; }
+        internal string FileName { get; private set; }
+        internal DateTime Date { get; private set; }
+
+        public SizeLimitedLogFileInfo(DateTime date, uint sequence)
+        {
+            this.Date = date;
+            this.Sequence = sequence;
+            this.FileName = String.Format("{0}-{1}.log", date.ToString(DateFormat), sequence.ToString(NumberFormat));
+        }
+
+        public SizeLimitedLogFileInfo Next()
+        {
+            DateTime now = DateTime.UtcNow;
+            if (this.Date.Date != now.Date)
+            {
+                return new SizeLimitedLogFileInfo(now, 1);
+            }
+
+            return new SizeLimitedLogFileInfo(now, this.Sequence + 1);
+        }
+
+        internal static SizeLimitedLogFileInfo GetLatestOrNew(DateTime date, string logDirectory)
+        {
+            string pattern = date.ToString(DateFormat) + @"-(\d{5}).log";
+
+            var logFileInfo = new SizeLimitedLogFileInfo(date, 1);
+
+            foreach (var filePath in Directory.GetFiles(logDirectory))
+            {
+                Match match = Regex.Match(filePath, pattern);
+                if (match.Success)
+                {
+                    var sequence = uint.Parse(match.Groups[1].Value);
+
+                    if (sequence > logFileInfo.Sequence)
+                    {
+                        logFileInfo = new SizeLimitedLogFileInfo(date, sequence);
+                    }
+                }
+            }
+
+            return logFileInfo;
+        }
+    }
+}

--- a/test/Serilog.Sinks.RollingFileAlternate.Tests/LogFileInfoTests.cs
+++ b/test/Serilog.Sinks.RollingFileAlternate.Tests/LogFileInfoTests.cs
@@ -9,7 +9,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Tests
         [Fact]
         public void RendersCorrectlyWithDateAndSequenceNumber()
         {
-            var sut = new LogFileInfo(new DateTime(2015, 01, 15), 77);
+            var sut = new SizeLimitedLogFileInfo(new DateTime(2015, 01, 15), 77);
             Assert.Equal(sut.FileName, "20150115-00077.log");
         }
     }

--- a/test/Serilog.Sinks.RollingFileAlternate.Tests/SizeLimitReachedTests.cs
+++ b/test/Serilog.Sinks.RollingFileAlternate.Tests/SizeLimitReachedTests.cs
@@ -14,7 +14,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Tests
         public void ReachedWhenAmountOfCharactersWritten()
         {
             var formatter = new RawFormatter();
-            var components = new LogFileInfo(new DateTime(2015, 01, 15), 0);
+            var components = new SizeLimitedLogFileInfo(new DateTime(2015, 01, 15), 0);
             var logFile = new SizeLimitedLogFileDescription(components, 1);
             using (var str = new MemoryStream())
             using (var wr = new StreamWriter(str, Encoding.UTF8))

--- a/test/Serilog.Sinks.RollingFileAlternate.Tests/SizeRollingFileSinkTests.cs
+++ b/test/Serilog.Sinks.RollingFileAlternate.Tests/SizeRollingFileSinkTests.cs
@@ -17,7 +17,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Tests
             {
                 using (var dir = new TestDirectory())
                 {
-                    var latest = LogFileInfo.GetLatestOrNew(new DateTime(2015, 01, 15), dir.LogDirectory);
+                    var latest = SizeLimitedLogFileInfo.GetLatestOrNew(new DateTime(2015, 01, 15), dir.LogDirectory);
                     Assert.Equal<uint>(latest.Sequence, 1);
                 }
             }
@@ -31,7 +31,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Tests
                     dir.CreateLogFile(date, 1);
                     dir.CreateLogFile(date, 2);
                     dir.CreateLogFile(date, 3);
-                    var latest = LogFileInfo.GetLatestOrNew(new DateTime(2015, 01, 15), dir.LogDirectory);
+                    var latest = SizeLimitedLogFileInfo.GetLatestOrNew(new DateTime(2015, 01, 15), dir.LogDirectory);
                     Assert.Equal<uint>(latest.Sequence, 3);
                 }
             }
@@ -74,7 +74,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Tests
             {
                 lock (_lock)
                 {
-                    string fileName = Path.Combine(this.folder, new LogFileInfo(date, sequence).FileName);
+                    string fileName = Path.Combine(this.folder, new SizeLimitedLogFileInfo(date, sequence).FileName);
                     File.Create(fileName).Dispose(); // touch
                 }
             }


### PR DESCRIPTION
This fixes the same issue that commit https://github.com/BedeGaming/sinks-rollingfile/commit/28693fc1d78761c10cd924eeba157f08d3b57c19 previously fixed for the other Sink. Hourly log files now have a sequence number appended to them and if the current log file can't be opened for writing then the sequence number is increased.