### PR TITLE
Overloaded RollingFileAlternate with a prefix for log file name.

### DIFF
--- a/examples/ExampleApp/Program.cs
+++ b/examples/ExampleApp/Program.cs
@@ -13,12 +13,18 @@ namespace ExampleApp
                 .WriteTo.ColoredConsole()
                 .CreateLogger();
 
+            var loggerWithPrefix = new LoggerConfiguration().MinimumLevel.Verbose()
+                .WriteTo.RollingFileAlternate(@"C:\logs\serilogtest\", fileSizeLimitBytes: 4096, logFilePrefix:"sample")
+                .WriteTo.ColoredConsole()
+                .CreateLogger();
+
             int messageCount = 0;
             while (true)
             {
                 for (int i = 0; i < 100; i++)
                 {
                     logger.Information("Message: {messageCount}", messageCount);
+                    loggerWithPrefix.Information("Message: {messageCount}", messageCount);
                     messageCount++;
                 }
                 Console.WriteLine("Enter to log 100 logs...");

--- a/examples/ExampleApp/project.json
+++ b/examples/ExampleApp/project.json
@@ -11,7 +11,7 @@
     },
     "Serilog": "2.0.0",
     "Serilog.Sinks.ColoredConsole": "2.0.0",
-    "Serilog.Sinks.RollingFileAlternate": "2.0"
+    "Serilog.Sinks.RollingFileAlternate": "2.0.7"
   },
 
   "frameworks": {

--- a/src/Serilog.Sinks.RollingFileAlternate/LoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/LoggerConfigurationExtensions.cs
@@ -51,7 +51,40 @@ namespace Serilog.Sinks.RollingFileAlternate
             var sink = new AlternateRollingFileSink(logDirectory, templateFormatter, fileSizeLimitBytes ?? TwoMegabytes, retainedFileCountLimit);
             return configuration.Sink(sink, minimumLevel);
         }
-        
+
+        /// <summary>
+        /// Creates an alternative implementation of the rolling file sink
+        /// that rolls files based on their size with an overload to pass log file name prefix
+        /// </summary>
+        /// <param name="configuration"><see cref="LoggerSinkConfiguration"/></param>
+        /// <param name="logDirectory">The names of the directory to be logged</param>
+        /// <param name="logFilePrefix">The prefix for the log file name.</param>
+        /// <param name="minimumLevel">Minimum <see cref="LogLevel"/></param>
+        /// <param name="outputTemplate">The template for substituting logged parameters</param>
+        /// <param name="formatProvider">A culture specific format provider</param>
+        /// <param name="fileSizeLimitBytes">The size files should grow up to (default 2MB)</param>
+        /// <param name="retainedFileCountLimit">The maximum number of log files that will be retained,
+        /// including the current log file. The default is null which is unlimited.</param>
+        /// <returns></returns>
+        public static LoggerConfiguration RollingFileAlternate(
+            this LoggerSinkConfiguration configuration,
+            string logDirectory, string logFilePrefix,
+            LogEventLevel minimumLevel = LevelAlias.Minimum,
+            string outputTemplate = DefaultOutputTemplate,
+            IFormatProvider formatProvider = null,
+            long? fileSizeLimitBytes = null,
+            int? retainedFileCountLimit = null)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException("configuration");
+            }
+
+            var templateFormatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
+            var sink = new AlternateRollingFileSink(logDirectory, templateFormatter, fileSizeLimitBytes ?? TwoMegabytes, retainedFileCountLimit, logFilePrefix: logFilePrefix);
+            return configuration.Sink(sink, minimumLevel);
+        }
+
         /// <summary>
         /// Creates an alternative implementation of the rolling file sink with
         /// an overload to pass an ITextFormatter.

--- a/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/AlternateRollingFileSink.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/AlternateRollingFileSink.cs
@@ -26,6 +26,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Sinks.SizeRollingFileSink
         private readonly object syncRoot = new object();
         private bool disposed;
         private readonly string logDirectory;
+        private readonly string logFilePrefix;
 
         /// <summary>
         /// Construct a <see cref="AlternateRollingFileSink"/>
@@ -35,18 +36,21 @@ namespace Serilog.Sinks.RollingFileAlternate.Sinks.SizeRollingFileSink
         /// <param name="fileSizeLimitBytes">
         /// The size in bytes at which a new file should be created</param>
         /// <param name="encoding"></param>
+        /// <param name="logFilePrefix">The prefix for the log file name.</param>
         public AlternateRollingFileSink(
             string logDirectory,
             ITextFormatter formatter,
             long fileSizeLimitBytes,
             int? retainedFileCountLimit = null,
-            Encoding encoding = null)
+            Encoding encoding = null,
+            string logFilePrefix = "")
         {
             this.formatter = formatter;
             this.fileSizeLimitBytes = fileSizeLimitBytes;
             this.retainedFileCountLimit = retainedFileCountLimit;
             this.encoding = encoding;
             this.logDirectory = logDirectory;
+            this.logFilePrefix = string.IsNullOrEmpty(logFilePrefix) ? logFilePrefix : $"{logFilePrefix}-";
             this.currentSink = GetLatestSink();
         }
 
@@ -89,12 +93,12 @@ namespace Serilog.Sinks.RollingFileAlternate.Sinks.SizeRollingFileSink
         {
             EnsureDirectoryCreated(this.logDirectory);
 
-            SizeLimitedLogFileInfo logFileInfo = SizeLimitedLogFileInfo.GetLatestOrNew(DateTime.UtcNow, this.logDirectory);
+            SizeLimitedLogFileInfo logFileInfo = SizeLimitedLogFileInfo.GetLatestOrNew(DateTime.UtcNow, this.logDirectory, this.logFilePrefix);
 
             return new SizeLimitedFileSink(
                 this.formatter,
                 this.logDirectory,
-                new SizeLimitedLogFileDescription(logFileInfo, this.fileSizeLimitBytes),
+                new SizeLimitedLogFileDescription(logFileInfo, this.fileSizeLimitBytes, this.logFilePrefix),
                 this.encoding);
         }
 

--- a/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/SizeLimitedLogFileDescription.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/SizeLimitedLogFileDescription.cs
@@ -4,18 +4,20 @@
     {
         public readonly long SizeLimitBytes;
         public readonly SizeLimitedLogFileInfo LogFileInfo;
+        public readonly string LogFilePrefix;
 
-        public SizeLimitedLogFileDescription(SizeLimitedLogFileInfo logFileInfo, long sizeLimitBytes)
+        public SizeLimitedLogFileDescription(SizeLimitedLogFileInfo logFileInfo, long sizeLimitBytes, string logFilePrefix)
         {
             LogFileInfo = logFileInfo;
             SizeLimitBytes = sizeLimitBytes;
+            LogFilePrefix = logFilePrefix;
         }
 
         public string FileName { get { return LogFileInfo.FileName; } }
 
         internal SizeLimitedLogFileDescription Next()
         {
-            return new SizeLimitedLogFileDescription(this.LogFileInfo.Next(), this.SizeLimitBytes);
+            return new SizeLimitedLogFileDescription(this.LogFileInfo.Next(LogFilePrefix), this.SizeLimitBytes, LogFilePrefix);
         }
     }
 }

--- a/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/SizeLimitedLogFileInfo.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/Sinks/SizeRollingFileSink/SizeLimitedLogFileInfo.cs
@@ -13,29 +13,29 @@ namespace Serilog.Sinks.RollingFileAlternate.Sinks.SizeRollingFileSink
         internal string FileName { get; private set; }
         internal DateTime Date { get; private set; }
 
-        public SizeLimitedLogFileInfo(DateTime date, uint sequence)
+        public SizeLimitedLogFileInfo(DateTime date, uint sequence, string logFilePrefix)
         {
             this.Date = date;
             this.Sequence = sequence;
-            this.FileName = String.Format("{0}-{1}.log", date.ToString(DateFormat), sequence.ToString(NumberFormat));
+            this.FileName = $"{logFilePrefix}{date.ToString(DateFormat)}-{sequence.ToString(NumberFormat)}.log";
         }
 
-        public SizeLimitedLogFileInfo Next()
+        public SizeLimitedLogFileInfo Next(string logFilePrefix)
         {
             DateTime now = DateTime.UtcNow;
             if (this.Date.Date != now.Date)
             {
-                return new SizeLimitedLogFileInfo(now, 1);
+                return new SizeLimitedLogFileInfo(now, 1, logFilePrefix);
             }
 
-            return new SizeLimitedLogFileInfo(now, this.Sequence + 1);
+            return new SizeLimitedLogFileInfo(now, this.Sequence + 1, logFilePrefix);
         }
 
-        internal static SizeLimitedLogFileInfo GetLatestOrNew(DateTime date, string logDirectory)
+        internal static SizeLimitedLogFileInfo GetLatestOrNew(DateTime date, string logDirectory, string logFilePrefix)
         {
-            string pattern = date.ToString(DateFormat) + @"-(\d{5}).log";
+            string pattern = $"{logFilePrefix}{date.ToString(DateFormat)}" + @"-(\d{5}).log";
 
-            var logFileInfo = new SizeLimitedLogFileInfo(date, 1);
+            var logFileInfo = new SizeLimitedLogFileInfo(date, 1, logFilePrefix);
 
             foreach (var filePath in Directory.GetFiles(logDirectory))
             {
@@ -46,7 +46,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Sinks.SizeRollingFileSink
 
                     if (sequence > logFileInfo.Sequence)
                     {
-                        logFileInfo = new SizeLimitedLogFileInfo(date, sequence);
+                        logFileInfo = new SizeLimitedLogFileInfo(date, sequence, logFilePrefix);
                     }
                 }
             }

--- a/test/Serilog.Sinks.RollingFileAlternate.Tests/LogFileInfoTests.cs
+++ b/test/Serilog.Sinks.RollingFileAlternate.Tests/LogFileInfoTests.cs
@@ -9,7 +9,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Tests
         [Fact]
         public void RendersCorrectlyWithDateAndSequenceNumber()
         {
-            var sut = new SizeLimitedLogFileInfo(new DateTime(2015, 01, 15), 77);
+            var sut = new SizeLimitedLogFileInfo(new DateTime(2015, 01, 15), 77, string.Empty);
             Assert.Equal(sut.FileName, "20150115-00077.log");
         }
     }

--- a/test/Serilog.Sinks.RollingFileAlternate.Tests/Serilog.Sinks.RollingFileAlternate.Tests.xproj
+++ b/test/Serilog.Sinks.RollingFileAlternate.Tests/Serilog.Sinks.RollingFileAlternate.Tests.xproj
@@ -4,7 +4,6 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>060cf269-c2bf-4529-8395-bde3c92fd151</ProjectGuid>
@@ -13,9 +12,11 @@
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/Serilog.Sinks.RollingFileAlternate.Tests/SizeLimitReachedTests.cs
+++ b/test/Serilog.Sinks.RollingFileAlternate.Tests/SizeLimitReachedTests.cs
@@ -14,8 +14,8 @@ namespace Serilog.Sinks.RollingFileAlternate.Tests
         public void ReachedWhenAmountOfCharactersWritten()
         {
             var formatter = new RawFormatter();
-            var components = new SizeLimitedLogFileInfo(new DateTime(2015, 01, 15), 0);
-            var logFile = new SizeLimitedLogFileDescription(components, 1);
+            var components = new SizeLimitedLogFileInfo(new DateTime(2015, 01, 15), 0, string.Empty);
+            var logFile = new SizeLimitedLogFileDescription(components, 1, string.Empty);
             using (var str = new MemoryStream())
             using (var wr = new StreamWriter(str, Encoding.UTF8))
             using (var sink = new SizeLimitedFileSink(formatter, logFile, wr))

--- a/test/Serilog.Sinks.RollingFileAlternate.Tests/SizeRollingFileSinkTests.cs
+++ b/test/Serilog.Sinks.RollingFileAlternate.Tests/SizeRollingFileSinkTests.cs
@@ -17,7 +17,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Tests
             {
                 using (var dir = new TestDirectory())
                 {
-                    var latest = SizeLimitedLogFileInfo.GetLatestOrNew(new DateTime(2015, 01, 15), dir.LogDirectory);
+                    var latest = SizeLimitedLogFileInfo.GetLatestOrNew(new DateTime(2015, 01, 15), dir.LogDirectory, string.Empty);
                     Assert.Equal<uint>(latest.Sequence, 1);
                 }
             }
@@ -31,7 +31,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Tests
                     dir.CreateLogFile(date, 1);
                     dir.CreateLogFile(date, 2);
                     dir.CreateLogFile(date, 3);
-                    var latest = SizeLimitedLogFileInfo.GetLatestOrNew(new DateTime(2015, 01, 15), dir.LogDirectory);
+                    var latest = SizeLimitedLogFileInfo.GetLatestOrNew(new DateTime(2015, 01, 15), dir.LogDirectory, string.Empty);
                     Assert.Equal<uint>(latest.Sequence, 3);
                 }
             }
@@ -74,7 +74,7 @@ namespace Serilog.Sinks.RollingFileAlternate.Tests
             {
                 lock (_lock)
                 {
-                    string fileName = Path.Combine(this.folder, new SizeLimitedLogFileInfo(date, sequence).FileName);
+                    string fileName = Path.Combine(this.folder, new SizeLimitedLogFileInfo(date, sequence, string.Empty).FileName);
                     File.Create(fileName).Dispose(); // touch
                 }
             }


### PR DESCRIPTION
Added a overloaded extension method RollingFileAlternate to pass a prefix for log file names.
The prefix is passed along to the AlternateRollingFileSink which will be used while creating the name for log file. If the prefix parameter is **not** passed to RollingFileAlternate, it will create the file names as earlier and the original behavior is not modified.
In case, if we need to have specific loggers configured to have specific events, this will be useful as it lets to specify prefix for log files, there by making them distinguishable from each other. 