### PR TITLE
Update File Retention Policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,12 @@ bld/
 # Visual Studo 2015 cache/options directory
 .vs/
 
+# Rider IDE
+.idea/
+
+# OSX
+.DS_Store
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/src/Serilog.Sinks.RollingFileAlternate/Sinks/FileRetentionPolicy.cs
+++ b/src/Serilog.Sinks.RollingFileAlternate/Sinks/FileRetentionPolicy.cs
@@ -1,0 +1,46 @@
+using System.IO;
+
+namespace Serilog.Sinks.RollingFileAlternate.Sinks
+{
+    public class FileRetentionPolicy
+    {
+        private readonly string logDirectory;
+        private readonly int? retainedFileCountLimit;
+        public FileRetentionPolicy(string logDirectory int? retainedFileCountLimit)
+        {
+            this.logDirectory = logDirectory;
+            this.retainedFileCountLimit = retainedFileCountLimit;
+        }
+        private void Apply(string currentFilename)
+        {
+            if (this.retainedFileCountLimit == null) return;
+
+            var filename = currentFilename.Substring(0, currentFilename.LastIndexOf("-"));
+            var regex = new Regex($"(/[0-9a-fA-F]*)+/{filename}-[0-9]{{5}}.log");
+
+            var newestFirst = Directory.GetFiles(this.logDirectory)
+                .Where(f => regex.IsMatch(f))
+                .Select(m => new FileInfo(m))
+                .OrderByDescending(m => m.CreationTime)
+                .Select(m => m.Name);
+
+            var toRemove = newestFirst
+                .Where(n => StringComparer.OrdinalIgnoreCase.Compare(currentFilename, n) != 0)
+                .Skip(this.retainedFileCountLimit.Value - 1)
+                .ToList();
+
+            foreach (var obsolete in toRemove)
+            {
+                var fullPath = Path.Combine(this.logDirectory, obsolete);
+                try
+                {
+                    File.Delete(fullPath);
+                }
+                catch (Exception ex)
+                {
+                    SelfLog.WriteLine("Error {0} while removing obsolete file {1}", ex, fullPath);
+                }
+            }
+        }
+    }
+}

--- a/test/Serilog.Sinks.RollingFileAlternate.Tests/FileRetentionLimitReachedTests.cs
+++ b/test/Serilog.Sinks.RollingFileAlternate.Tests/FileRetentionLimitReachedTests.cs
@@ -1,0 +1,89 @@
+﻿namespace Serilog.Sinks.RollingFileAlternate.Tests
+{
+    using System.IO;
+    using Formatting.Raw;
+    using Sinks.SizeRollingFileSink;
+    using Support;
+    using Xunit;
+
+    public class FileRetentionLimitReachedTests
+    {
+        [Fact]
+        public void ItDeletesTheOldestFiles()
+        {
+            using (var dir = new TestDirectory())
+            {
+                using (var sizeRollingSink = new AlternateRollingFileSink(dir.LogDirectory, new RawFormatter(), 1, 3))
+                {
+                    var logEvent = Some.InformationEvent();
+                    sizeRollingSink.Emit(logEvent);
+                    sizeRollingSink.Emit(logEvent);
+                    sizeRollingSink.Emit(logEvent);
+                    sizeRollingSink.Emit(logEvent);
+                    sizeRollingSink.Emit(logEvent);
+
+                    Assert.Equal<uint>(sizeRollingSink.CurrentLogFile.LogFileInfo.Sequence, 5);
+                    Assert.Equal(4, Directory.GetFiles(dir.LogDirectory).Length);
+                }
+            }
+        }
+        
+        [Fact]
+        public void ItIgnoresFilesFromOtherSinks()
+        {
+            using (var dir = new TestDirectory())
+            {
+                using (var sizeRollingSink = new AlternateRollingFileSink(dir.LogDirectory, new RawFormatter(), 1, 3,logFilePrefix: "Ignore"))
+                {
+                    var logEvent = Some.InformationEvent();
+                    sizeRollingSink.Emit(logEvent);
+                }
+                
+                using (var sizeRollingSink = new AlternateRollingFileSink(dir.LogDirectory, new RawFormatter(), 1, 3))
+                {
+                    var logEvent = Some.InformationEvent();
+                    sizeRollingSink.Emit(logEvent);
+                    sizeRollingSink.Emit(logEvent);
+                    sizeRollingSink.Emit(logEvent);
+                    sizeRollingSink.Emit(logEvent);
+                    sizeRollingSink.Emit(logEvent);
+                    
+                    var files = Directory.GetFiles(dir.LogDirectory);
+                    
+                    Assert.Equal<uint>(sizeRollingSink.CurrentLogFile.LogFileInfo.Sequence, 5);
+                    Assert.Contains(files, x => x.Substring(x.LastIndexOf("/") +1).StartsWith("Ignore"));
+                    Assert.Equal(5, files.Length);
+                }
+            }
+        }
+        
+        [Fact]
+        public void ItIgnoresFilesFromOtherSinksWithPrefix()
+        {
+            using (var dir = new TestDirectory())
+            {
+                using (var sizeRollingSink = new AlternateRollingFileSink(dir.LogDirectory, new RawFormatter(), 1, 3,logFilePrefix: "Ignore"))
+                {
+                    var logEvent = Some.InformationEvent();
+                    sizeRollingSink.Emit(logEvent);
+                }
+                
+                using (var sizeRollingSink = new AlternateRollingFileSink(dir.LogDirectory, new RawFormatter(), 1, 3,logFilePrefix: "DoNotIgnore"))
+                {
+                    var logEvent = Some.InformationEvent();
+                    sizeRollingSink.Emit(logEvent);
+                    sizeRollingSink.Emit(logEvent);
+                    sizeRollingSink.Emit(logEvent);
+                    sizeRollingSink.Emit(logEvent);
+                    sizeRollingSink.Emit(logEvent);
+                    
+                    var files = Directory.GetFiles(dir.LogDirectory);
+                    
+                    Assert.Equal<uint>(sizeRollingSink.CurrentLogFile.LogFileInfo.Sequence, 5);
+                    Assert.Contains(files, x => x.Substring(x.LastIndexOf("/") +1).StartsWith("Ignore"));
+                    Assert.Equal(5, files.Length);
+                }
+            }
+        }
+    }
+}

--- a/test/Serilog.Sinks.RollingFileAlternate.Tests/SizeRollingFileSinkTests.cs
+++ b/test/Serilog.Sinks.RollingFileAlternate.Tests/SizeRollingFileSinkTests.cs
@@ -50,51 +50,5 @@ namespace Serilog.Sinks.RollingFileAlternate.Tests
                 Assert.Equal<uint>(sizeRollingSink.CurrentLogFile.LogFileInfo.Sequence, 2);
             }
         }
-
-        private class TestDirectory : IDisposable
-        {
-            private readonly string folder;
-            private readonly object _lock = new object();
-            private static readonly string SystemTemp = Path.GetTempPath() + "Serilog-SizeRollingFileTests";
-            private bool disposed;
-
-            public TestDirectory()
-            {
-                var subfolderPath = Path.Combine(SystemTemp, Guid.NewGuid().ToString("N"));
-                var di = 
-                    Directory.Exists(subfolderPath)
-                        ? new DirectoryInfo(subfolderPath)
-                        : Directory.CreateDirectory(subfolderPath);
-                this.folder = di.FullName;
-            }
-
-            public string LogDirectory { get { return this.folder; } }
-
-            public void CreateLogFile(DateTime date, uint sequence)
-            {
-                lock (_lock)
-                {
-                    string fileName = Path.Combine(this.folder, new SizeLimitedLogFileInfo(date, sequence, string.Empty).FileName);
-                    File.Create(fileName).Dispose(); // touch
-                }
-            }
-
-            public void Dispose()
-            {
-                lock (_lock)
-                {
-                    if (this.disposed) return;
-                    try
-                    {
-                        Directory.GetFiles(this.folder).ToList().ForEach(File.Delete);
-                        Directory.Delete(this.folder);
-                    }
-                    finally
-                    {
-                        this.disposed = true;
-                    }
-                }
-            }
-        }
     }
 }

--- a/test/Serilog.Sinks.RollingFileAlternate.Tests/TestDirectory.cs
+++ b/test/Serilog.Sinks.RollingFileAlternate.Tests/TestDirectory.cs
@@ -1,0 +1,53 @@
+﻿namespace Serilog.Sinks.RollingFileAlternate.Tests
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using Sinks.SizeRollingFileSink;
+
+    public class TestDirectory : IDisposable
+    {
+        private readonly string folder;
+        private readonly object _lock = new object();
+        private static readonly string SystemTemp = Path.GetTempPath() + "Serilog-SizeRollingFileTests";
+        private bool disposed;
+
+        public TestDirectory()
+        {
+            var subfolderPath = Path.Combine(SystemTemp, Guid.NewGuid().ToString("N"));
+            var di = 
+                Directory.Exists(subfolderPath)
+                    ? new DirectoryInfo(subfolderPath)
+                    : Directory.CreateDirectory(subfolderPath);
+            this.folder = di.FullName;
+        }
+
+        public string LogDirectory { get { return this.folder; } }
+
+        public void CreateLogFile(DateTime date, uint sequence)
+        {
+            lock (_lock)
+            {
+                string fileName = Path.Combine(this.folder, new SizeLimitedLogFileInfo(date, sequence, string.Empty).FileName);
+                File.Create(fileName).Dispose(); // touch
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                if (this.disposed) return;
+                try
+                {
+                    Directory.GetFiles(this.folder).ToList().ForEach(File.Delete);
+                    Directory.Delete(this.folder);
+                }
+                finally
+                {
+                    this.disposed = true;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #42 

Uses pattern matching to select only the files in the directory that have a similar pattern to the current sinks filename.

Moves the file retention code to a common class used by both the `HourlyRollingFileSink` & `AlternateRollingFileSink`.

New tests added and pass.